### PR TITLE
Language selection functionality

### DIFF
--- a/HokkienTranslation/App.js
+++ b/HokkienTranslation/App.js
@@ -14,6 +14,7 @@ import UpdateFlashcardScreen from "./screens/UpdateFlashcardScreen";
 import QuizScreen from "./screens/QuizScreen";
 import FlashcardCategory from "./screens/FlashcardCategory";
 import ThemeProvider, { useTheme } from "./screens/context/ThemeProvider";
+import { LanguageProvider } from "./screens/context/LanguageProvider";
 import { ComponentVisibilityProvider } from "./screens/context/ComponentVisibilityContext";
 import FeedbackButton from "./screens/components/FeedbackButton";
 
@@ -141,9 +142,11 @@ const AppContent = () => {
 export default function App() {
   return (
     <ThemeProvider>
-      <ComponentVisibilityProvider>
-        <AppContent />
-      </ComponentVisibilityProvider>
+      <LanguageProvider>
+        <ComponentVisibilityProvider>
+          <AppContent />
+        </ComponentVisibilityProvider>
+      </LanguageProvider>
     </ThemeProvider>
   );
 }

--- a/HokkienTranslation/package-lock.json
+++ b/HokkienTranslation/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "18.2.0",
         "react-icons": "^5.2.1",
         "react-native": "0.72.10",
+        "react-native-dropdown-select-list": "^2.0.5",
         "react-native-progress": "^5.0.1",
         "react-native-reanimated": "^3.12.0",
         "react-native-screens": "~3.22.0",
@@ -19531,6 +19532,11 @@
       "peerDependencies": {
         "@babel/runtime": "^7.20.6"
       }
+    },
+    "node_modules/react-native-dropdown-select-list": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-dropdown-select-list/-/react-native-dropdown-select-list-2.0.5.tgz",
+      "integrity": "sha512-TepbcagQVUMB6nLuIlVU2ghRpQHAECOeZWe8K04ymW6NqbKbxuczZSDFfdCiABiiQ2dFD+8Dz65y4K7/uUEqGg=="
     },
     "node_modules/react-native-progress": {
       "version": "5.0.1",

--- a/HokkienTranslation/package.json
+++ b/HokkienTranslation/package.json
@@ -32,6 +32,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^5.2.1",
     "react-native": "0.72.10",
+    "react-native-dropdown-select-list": "^2.0.5",
     "react-native-progress": "^5.0.1",
     "react-native-reanimated": "^3.12.0",
     "react-native-screens": "~3.22.0",

--- a/HokkienTranslation/screens/FlashcardScreen.js
+++ b/HokkienTranslation/screens/FlashcardScreen.js
@@ -1,9 +1,11 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Box, Text, Button, Center, VStack, HStack, Pressable } from "native-base";
 import { Ionicons } from "@expo/vector-icons";
 import { TouchableOpacity, Modal, Animated, PanResponder } from "react-native";
 import NavigationButtons from "../screens/components/ScreenNavigationButtons";
 import { useTheme } from "./context/ThemeProvider";
+import { useLanguage } from "./context/LanguageProvider";
+import { callOpenAIChat } from "../backend/API/OpenAIChatService";
 
 const FlashcardScreen = ({ navigation }) => {
   const { theme, themes } = useTheme();
@@ -15,6 +17,8 @@ const FlashcardScreen = ({ navigation }) => {
   const [isPressedRight, setIsPressedRight] = useState(false);
   const [isMin, setIsMin] = useState(true);
   const [isMax, setIsMax] = useState(false);
+  const { language } = useLanguage();
+  const [translatedText, setTranslatedText] = useState("");
 
   const flashcards = [
     { word: "Apple", translation: "苹果 (Píngguǒ)" },
@@ -94,6 +98,28 @@ const FlashcardScreen = ({ navigation }) => {
     setShowConfirmDelete(false);
   };
 
+  useEffect(() => {
+    if (language != "Chinese (Simplified)") {
+      if (showTranslation) {
+        const translateText = async () => {
+          await callOpenAIChat(
+            `Translate ${flashcards[currentCardIndex].translation} to ${language}. 
+            You must respond with only the translation.`)
+          .then((response) => { 
+            console.log("OpenAI Response:", response);
+            setTranslatedText(response)
+          })
+          .catch((error) => console.error("Error:", error));
+        };
+        setTranslatedText("Loading...")
+        translateText();
+      }
+    } else {
+      setTranslatedText(flashcards[currentCardIndex].translation);
+    }
+  }, [showTranslation, currentCardIndex, language]);
+  
+  
   return (
     <Box flex={1} background={colors.surface}>
       <NavigationButtons colors={colors} />
@@ -186,7 +212,7 @@ const FlashcardScreen = ({ navigation }) => {
               >
                 <Text fontSize="2xl" color={colors.onSurface}>
                   {showTranslation
-                    ? flashcards[currentCardIndex].translation
+                    ? translatedText
                     : flashcards[currentCardIndex].word}
                 </Text>
               </Box>

--- a/HokkienTranslation/screens/SettingsScreen.js
+++ b/HokkienTranslation/screens/SettingsScreen.js
@@ -3,12 +3,38 @@ import { Pressable } from "react-native";
 import { Switch, HStack, VStack, Text } from "native-base";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "./context/ThemeProvider";
+import { useLanguage } from "./context/LanguageProvider";
 import { useComponentVisibility } from "./context/ComponentVisibilityContext";
+import { SelectList } from "react-native-dropdown-select-list";
 
 const SettingsScreen = () => {
   const { theme, toggleTheme, themes } = useTheme();
   const colors = themes[theme];
   const { visibilityStates, toggleVisibility } = useComponentVisibility();
+  const { language, setLanguage } = useLanguage();
+
+  const languages = [
+    { key: '1', value: "Arabic" },
+    { key: '2', value: "Chinese (Simplified)" },
+    { key: '3', value: "Chinese (Traditional)" },
+    { key: '4', value: "Czech" },
+    { key: '5', value: "Danish" },
+    { key: '6', value: "Dutch" },
+    { key: '7', value: "French" },
+    { key: '8', value: "German" },
+    { key: '9', value: "Greek" },
+    { key: '10', value: "Hindi" },
+    { key: '11', value: "Indonesian" },
+    { key: '12', value: "Italian" },
+    { key: '13', value: "Japanese" },
+    { key: '14', value: "Korean" },
+    { key: '15', value: "Polish" },
+    { key: '16', value: "Portuguese" },
+    { key: '17', value: "Russian" },
+    { key: '18', value: "Spanish" },
+    { key: '19', value: "Turkish" },
+    { key: '20', value: "Vietnamese" }
+  ];
 
   const ThemeOption = ({ themeName, iconName }) => (
     <Pressable
@@ -84,6 +110,26 @@ const SettingsScreen = () => {
               }
             />
           </VStack>
+        </VStack>
+
+        {/* Language section */}
+        <VStack space={2}>
+          <Text
+            style={{
+              fontSize: 18,
+              fontWeight: "bold",
+              color: colors.onSurface,
+            }}
+          >
+            Language Options
+          </Text>
+          <SelectList
+            setSelected={(val) => setLanguage(val)}
+            data={languages}
+            save="value"
+            // search={false}
+            defaultOption={{ key:'2', value:'Chinese (Simplified)' }}
+          />  
         </VStack>
 
         {/* Models section */}

--- a/HokkienTranslation/screens/context/LanguageProvider.js
+++ b/HokkienTranslation/screens/context/LanguageProvider.js
@@ -1,0 +1,17 @@
+import { createContext, useContext, useState } from "react";
+
+const LanguageContext = createContext();
+
+export const useLanguage = () => useContext(LanguageContext);
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState('Chinese (Simplified)');
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export default LanguageProvider;


### PR DESCRIPTION
In the settings screen, users can search and select from 20 common languages (can be easily expanded) on a drop-down menu. Right now, this only changes the "back" of the flashcard -- the only option for the "front" of the card is English. 
OpenAI can take 1-2 seconds to respond, so there's a loading text when flipping the card.